### PR TITLE
Make Tokenizer thread safe

### DIFF
--- a/include/en_tokenizer.h
+++ b/include/en_tokenizer.h
@@ -8,13 +8,11 @@ namespace qnlp {
     class Tokenizer_en: public Tokenizer {
         public:
           
-            Tokenizer_en (istream* in, int syntax=PLAIN, bool lowercased=true, bool underscore=true, bool dash=true, bool aggressive=true, bool nopunct=true):
-                Tokenizer(in, syntax, lowercased, underscore, dash, aggressive, nopunct){lang="en";};
             Tokenizer_en (int syntax=PLAIN, bool lowercased=true, bool underscore=true, bool dash=true, bool aggressive=true, bool nopunct=true):
                 Tokenizer (syntax, lowercased, underscore, dash, aggressive, nopunct){lang="en";};
         protected:
-            bool proc (string& token, char& c);
-            bool proc_empty (string& token, char& c);
+            bool proc (string& token, char& c, streambuf* sbuf);
+            bool proc_empty (string& token, char& c, streambuf* sbuf);
     };
 }
 

--- a/include/fr_tokenizer.h
+++ b/include/fr_tokenizer.h
@@ -8,14 +8,12 @@ namespace qnlp {
     class Tokenizer_fr: public Tokenizer {
         public:
           
-            Tokenizer_fr (istream* in, int syntax=PLAIN, bool lowercased=true, bool underscore=true, bool dash=true, bool aggressive=true, bool nopunct=true):
-                Tokenizer(in, syntax, lowercased, underscore, dash, aggressive, nopunct){lang="fr";};
             Tokenizer_fr (int syntax=PLAIN, bool lowercased=true, bool underscore=true, bool dash=true, bool aggressive=true, bool nopunct=true):
                 Tokenizer (syntax, lowercased, underscore, dash, aggressive, nopunct){lang="fr";};
             
         protected:
-            bool proc (string& token, char& c);
-            bool proc_empty (string& token, char& c);
+            bool proc (string& token, char& c, streambuf* sbuf);
+            bool proc_empty (string& token, char& c, streambuf* sbuf);
     };
 }
 

--- a/include/tokenizer.h
+++ b/include/tokenizer.h
@@ -79,7 +79,6 @@ class Tokenizer {
         bool underscore; // set it to true if you want to split words with underscores
         bool aggressive; // set it to true if you want to split words with everyseparators
         bool no_punct; // set it to true if you want to remove everyseparators implies to activate the aggressive mode 
-        bool do_read;
 
         bool seps_wide (char& c);
         bool seps (char& c);

--- a/include/tokenizer.h
+++ b/include/tokenizer.h
@@ -18,22 +18,18 @@ class Tokenizer {
         enum {PLAIN, XHTML, CARACTER};
 
         /** Constructor of the class tokenizer */
-        Tokenizer (istream* in, int syntax=PLAIN, bool lowercased=true, bool underscore=true, bool dash=true, bool aggressive=true, bool noPunct=true):
-            in(in), syntax(syntax), lowercased(lowercased), underscore(underscore), dash(dash), aggressive(aggressive), no_punct(noPunct)
-            {sb = in->rdbuf();lang="gen";}
-
         Tokenizer (int syntax=PLAIN, bool lowercased=true, bool underscore=true, bool dash=true, bool aggressive=true, bool noPunct=true):
             syntax(syntax), lowercased(lowercased), underscore(underscore), dash(dash), aggressive(aggressive), no_punct(noPunct)
-            {istringstream iss("");sb = iss.rdbuf();lang="gen";}
+            {lang="gen";}
 
         vector<string> tokenize_sentence(string &text);
         string tokenize_sentence_to_string(string &text);
-        vector<string> tokenize(void);
-        string tokenize_to_string(void);
+        vector<string> tokenize(streambuf* sbuf);
+        string tokenize_to_string(streambuf* sbuf);
         string normalize(string &token);
         vector<string> normalize(vector<string> &vecToken);
 
-        bool read (string &token, bool newdoc);
+        bool read (string &token, bool newdoc, streambuf* sbuf);
 
         void setParam(bool lowercased, bool underscore, bool dash, bool aggressive, bool noPunct) {
             this->lowercased = lowercased;
@@ -72,12 +68,10 @@ class Tokenizer {
         string getlang();
 
     protected:
-        virtual bool proc (string& token, char& c);
-        virtual bool proc_empty (string& token, char& c);
+        virtual bool proc (string& token, char& c, streambuf* sbuf);
+        virtual bool proc_empty (string& token, char& c, streambuf* sbuf);
         string lang;
 
-        istream* in;
-        streambuf* sb;
         int syntax;
 
         bool lowercased; // set it to true if you want your output to be lowercased
@@ -95,11 +89,11 @@ class Tokenizer {
         bool stopChecker (string& ref, string& leq);
         bool is_abrv (string& token);
         bool is_nbr (string& token);
-        bool dot_proc (string& token, char& c);
-        bool comma_proc (string& token, char& c);
+        bool dot_proc (string& token, char& c, streambuf* sbuf);
+        bool comma_proc (string& token, char& c, streambuf* sbuf);
         
         string flag;
-        int parserXHTML (char& c, xmlDom& dom);
+        int parserXHTML (char& c, xmlDom& dom, streambuf* sbuf);
 
         const map<string,string> html_codex = { {"<",">"}, {"<!--","-->"}, {"<!", ">"},
             {"<?", "?>"}, {"</", ">"} };

--- a/src/en_tokenizer.cc
+++ b/src/en_tokenizer.cc
@@ -2,7 +2,7 @@
 
 using namespace qnlp;
 
-bool Tokenizer_en::proc(string& token, char& c) 
+bool Tokenizer_en::proc(string& token, char& c, streambuf* sbuf) 
 {
     int tksize=(int)token.size();
     if (!aggressive)
@@ -17,8 +17,8 @@ bool Tokenizer_en::proc(string& token, char& c)
             else
             {
                 token=token.substr(0,1);
-                sb->sungetc();
-                sb->sungetc();
+                sbuf->sungetc();
+                sbuf->sungetc();
                 return true;
             }
         }
@@ -27,7 +27,7 @@ bool Tokenizer_en::proc(string& token, char& c)
             case '\'':
                 token.push_back(c);
                 tksize=(int)token.size();
-                if ((c = sb->sbumpc()) != EOF)
+                if ((c = sbuf->sbumpc()) != EOF)
                 {
                     if (tksize == 2 && (token[0]=='O' || token[0]=='o'))
                     {
@@ -36,9 +36,9 @@ bool Tokenizer_en::proc(string& token, char& c)
                     }
                     if (tksize > 2 && c == 't' && token.at((tksize)-2) == 'n')
                     {
-                        sb->sungetc();
-                        sb->sputbackc('\'');
-                        sb->sputbackc('n');
+                        sbuf->sungetc();
+                        sbuf->sputbackc('\'');
+                        sbuf->sputbackc('n');
                         if (token.at((tksize)-3) == 'a')
                         {
                                 token=token.substr(0,(tksize)-1);
@@ -53,19 +53,19 @@ bool Tokenizer_en::proc(string& token, char& c)
                     {
                         if (tksize == 2 && token[0]!='n')
                         {
-                            sb->sungetc();
+                            sbuf->sungetc();
                             if (token[0]=='I' || token[0]=='i')
                             {
-                                sb->sputbackc('\'');
+                                sbuf->sputbackc('\'');
                                 token=token.substr(0,(tksize)-1);
                             }
                             return true;
                         }
                         if (tksize > 2 && c=='s')
                         {
-                            sb->sungetc();
-                            sb->sputbackc('\'');
-                            sb->sputbackc('s');
+                            sbuf->sungetc();
+                            sbuf->sputbackc('\'');
+                            sbuf->sputbackc('s');
                             token=token.substr(0,(tksize)-1);
                             return true;
                         }
@@ -75,73 +75,73 @@ bool Tokenizer_en::proc(string& token, char& c)
                               ((token[0]=='S' || token[0]=='s') && (token[1]=='H' || token[1]=='h') && (token[2]=='E' || token[2]=='e')) ||
                               ((token[0]=='H' || token[0]=='h') && (token[1]=='E' || token[1]=='e'))) 
                             {
-                                sb->sungetc();
-                                sb->sputbackc('\'');
+                                sbuf->sungetc();
+                                sbuf->sputbackc('\'');
                                 token=token.substr(0,(tksize)-1);
                                 return true;
                             }                            
                         }
                         if (seps(c))
                         {
-                            sb->sungetc();
-                            sb->sputbackc('\'');
-                            sb->sputbackc(c);
+                            sbuf->sungetc();
+                            sbuf->sputbackc('\'');
+                            sbuf->sputbackc(c);
                             token=token.substr(0,((int)token.size())-1);
                             return true;
                         }
                         token.push_back(c);
-                        // sb->sungetc();
+                        // sbuf->sungetc();
                         return true;
                     }
                 }
                 // if (token.at(0) == '\'' 
-                sb->sungetc();
+                sbuf->sungetc();
                 return true;
             case '.':
-                if (dot_proc(token,c)) return true;
+                if (dot_proc(token,c,sbuf)) return true;
                 else return false;
                 break;
             case ',':
-                if (comma_proc(token,c)) return true;
+                if (comma_proc(token,c,sbuf)) return true;
                 else return false;
                 break;
             default:
-                sb->sungetc();
+                sbuf->sungetc();
                 return true;
                 break;
         }
     }
     else
     {
-        if (!no_punct) sb->sungetc();
+        if (!no_punct) sbuf->sungetc();
         return true;
     }
 }
 
 
-bool Tokenizer_en::proc_empty(string& token, char& c)
+bool Tokenizer_en::proc_empty(string& token, char& c, streambuf* sbuf)
 {
     switch(c)
     {
         case '\'':
             token.push_back(c);
-            if ((c = sb->sbumpc()) != EOF)
+            if ((c = sbuf->sbumpc()) != EOF)
             {
                 if (c == 't' || c == 's' || c == 'm' || c == 'r')
                 {
                     token.push_back(c);
                     char c_tmp=c;
-                    if ((c = sb->sbumpc()) != EOF)
+                    if ((c = sbuf->sbumpc()) != EOF)
                     {
                         if (! seps(c) && c != 'e' )
                         {
-                            sb->sungetc();
+                            sbuf->sungetc();
                             if (c != '\'' )
                             {
-                                sb->sputbackc(c_tmp);
+                                sbuf->sputbackc(c_tmp);
                                 token=token.substr(0,((int)token.size())-1);
                             }
-                            sb->sputbackc(c);
+                            sbuf->sputbackc(c);
                             return true;
                         }
                         else
@@ -154,7 +154,7 @@ bool Tokenizer_en::proc_empty(string& token, char& c)
                 }
                 else
                 {
-                    sb->sungetc();
+                    sbuf->sungetc();
                     return true;
                 }
             }
@@ -165,7 +165,7 @@ bool Tokenizer_en::proc_empty(string& token, char& c)
             break;
         case '.':
             if (!no_punct) token.push_back(c);
-            if ((c = sb->sbumpc()) != EOF)
+            if ((c = sbuf->sbumpc()) != EOF)
             {
                 if (c == '.')
                 {
@@ -174,7 +174,7 @@ bool Tokenizer_en::proc_empty(string& token, char& c)
                 }
                 else
                 {
-                    sb->sungetc();
+                    sbuf->sungetc();
                     return true;
                 }
             }
@@ -187,7 +187,7 @@ bool Tokenizer_en::proc_empty(string& token, char& c)
             if (c < 0)
             {
                 token.push_back(c);
-                if ((c = sb->sbumpc()) != EOF)
+                if ((c = sbuf->sbumpc()) != EOF)
                 {
                     if (c < 0)
                     {
@@ -195,13 +195,13 @@ bool Tokenizer_en::proc_empty(string& token, char& c)
                     }
                     else
                     {
-                        c=sb->sungetc();
+                        c=sbuf->sungetc();
                         return true;
                     }
                       
                       
                 }
-                if ((c = sb->sbumpc()) != EOF)
+                if ((c = sbuf->sbumpc()) != EOF)
                 {
                     if (c < 0)
                     {
@@ -209,7 +209,7 @@ bool Tokenizer_en::proc_empty(string& token, char& c)
                     }
                     else
                     {
-                        c=sb->sungetc();
+                        c=sbuf->sungetc();
                         return true;
                     }
                 }

--- a/src/fr_tokenizer.cc
+++ b/src/fr_tokenizer.cc
@@ -7,6 +7,7 @@ bool Tokenizer_fr::proc(string& token, char& c, streambuf* sbuf) {
     {
         if (is_nbr(token)) 
         {
+            cerr << "is nbr " << token << endl;
             if ((int)token.size() >= 2 && token[(int)token.size()-2] <= '\x039' && token[(int)token.size()-2] >= '\x030' && token[(int)token.size()-1] == '.')
             {
                 char l_char=token.substr((int)token.size()-1,1)[0];

--- a/src/fr_tokenizer.cc
+++ b/src/fr_tokenizer.cc
@@ -2,7 +2,7 @@
 
 using namespace qnlp;
 
-bool Tokenizer_fr::proc(string& token, char& c) {
+bool Tokenizer_fr::proc(string& token, char& c, streambuf* sbuf) {
     if (!aggressive)
     {
         if (is_nbr(token)) 
@@ -11,9 +11,9 @@ bool Tokenizer_fr::proc(string& token, char& c) {
             {
                 char l_char=token.substr((int)token.size()-1,1)[0];
                 token=token.substr(0,(int)token.size()-1);
-                c=sb->sungetc();
-                c=sb->sungetc();
-                sb->sputbackc(l_char);
+                c=sbuf->sungetc();
+                c=sbuf->sungetc();
+                sbuf->sputbackc(l_char);
                 return true;
             }
         }
@@ -29,13 +29,13 @@ bool Tokenizer_fr::proc(string& token, char& c) {
                 if ((int)token.find("squ") > -1) return true;
                 if ((int)token.size() >= 2 && token[0]=='q' && token[1]=='u') return true;
                 if ((int)token.size() == 2) return true;
-                if ((int)token.size() >= 3) {token=token.substr(0,((int)token.size())-1);sb->sungetc();return true;}
+                if ((int)token.size() >= 3) {token=token.substr(0,((int)token.size())-1);sbuf->sungetc();return true;}
                 break;
             case '.':
-                if (dot_proc(token,c)) return true;
+                if (dot_proc(token,c,sbuf)) return true;
                 else return false;
             case ',':
-                if (comma_proc(token,c)) return true;
+                if (comma_proc(token,c,sbuf)) return true;
                 else return false;
                 break;
             default:
@@ -44,7 +44,7 @@ bool Tokenizer_fr::proc(string& token, char& c) {
                     if (c == -30 && (int)token.size() == 1)
                     {
                         token.push_back(c);
-                        if ((c = sb->sbumpc()) != EOF)
+                        if ((c = sbuf->sbumpc()) != EOF)
                         {
                             if (!seps(c))
                             {
@@ -53,13 +53,13 @@ bool Tokenizer_fr::proc(string& token, char& c) {
                             else
                             {
                                 token=token.substr(0,((int)token.size())-1);
-                                sb->sungetc();
-                                sb->sungetc();
-                                sb->sputbackc(c);
+                                sbuf->sungetc();
+                                sbuf->sungetc();
+                                sbuf->sputbackc(c);
                                 return true;                                                      
                             }
                         }
-                        if ((c = sb->sbumpc()) != EOF)
+                        if ((c = sbuf->sbumpc()) != EOF)
                         {
                             if (!seps(c))
                             {
@@ -68,37 +68,37 @@ bool Tokenizer_fr::proc(string& token, char& c) {
                             else
                             {
                                 token=token.substr(0,((int)token.size())-1);
-                                sb->sungetc();
-                                sb->sungetc();
-                                sb->sputbackc(c);
+                                sbuf->sungetc();
+                                sbuf->sungetc();
+                                sbuf->sputbackc(c);
                                 return true;                                                      
                             }
                         }
                         return true;
                     }
-                    if (!no_punct) sb->sungetc();
+                    if (!no_punct) sbuf->sungetc();
                     return true;
                 }
-                if (!no_punct) sb->sungetc();
+                if (!no_punct) sbuf->sungetc();
                 return true;
                 break;
         }
     }
     else
     {
-        if (!no_punct) sb->sungetc();
+        if (!no_punct) sbuf->sungetc();
         return true;
     }
     return false;
 }
 
 
-bool Tokenizer_fr::proc_empty(string& token, char& c){
+bool Tokenizer_fr::proc_empty(string& token, char& c, streambuf* sbuf){
     switch(c)
     {
         case '.':
             if (!no_punct) token.push_back(c);
-            if ((c = sb->sbumpc()) != EOF)
+            if ((c = sbuf->sbumpc()) != EOF)
             {
                 if (c == '.')
                 {
@@ -107,7 +107,7 @@ bool Tokenizer_fr::proc_empty(string& token, char& c){
                 }
                 else
                 {
-                    sb->sungetc();
+                    sbuf->sungetc();
                     return true;
                 }
             }
@@ -120,7 +120,7 @@ bool Tokenizer_fr::proc_empty(string& token, char& c){
             if (c < 0)
             {
                 if (!no_punct) token.push_back(c);
-                if ((c = sb->sbumpc()) != EOF)
+                if ((c = sbuf->sbumpc()) != EOF)
                 {
                     if (c < 0)
                     {
@@ -134,13 +134,13 @@ bool Tokenizer_fr::proc_empty(string& token, char& c){
                     }
                     else
                     {
-                        if (!no_punct) c=sb->sungetc();
+                        if (!no_punct) c=sbuf->sungetc();
                         return true;
                     }
                       
                       
                 }
-                if ((c = sb->sbumpc()) != EOF)
+                if ((c = sbuf->sbumpc()) != EOF)
                 {
                     if (c < 0)
                     {
@@ -148,7 +148,7 @@ bool Tokenizer_fr::proc_empty(string& token, char& c){
                     }
                     else
                     {
-                        if (!no_punct) c=sb->sungetc();
+                        if (!no_punct) c=sbuf->sungetc();
                         return true;
                     }
                 }

--- a/src/fr_tokenizer.cc
+++ b/src/fr_tokenizer.cc
@@ -7,7 +7,6 @@ bool Tokenizer_fr::proc(string& token, char& c, streambuf* sbuf) {
     {
         if (is_nbr(token)) 
         {
-            cerr << "is nbr " << token << endl;
             if ((int)token.size() >= 2 && token[(int)token.size()-2] <= '\x039' && token[(int)token.size()-2] >= '\x030' && token[(int)token.size()-1] == '.')
             {
                 char l_char=token.substr((int)token.size()-1,1)[0];

--- a/src/tokenizer.cc
+++ b/src/tokenizer.cc
@@ -231,18 +231,26 @@ bool Tokenizer::dot_proc(string& token, char& c, streambuf* sbuf)
 {
     token.push_back(c);
     int tksize=(int)token.size();
-    if (is_nbr(token)) 
-    {
-        if (tksize > 2 && token[tksize-3] <= '\x039' && token[tksize-3] >= '\x030' && token[tksize-2] == '.' && seps(token[tksize-1]))
+    if (is_nbr(token)) {
+        if ((c = sbuf->sbumpc()) != EOF) {
+            if (!seps(c)) {
+                token.push_back(c);
+                return false;
+            } else {
+                token = token.substr(0,tksize-1);
+                sbuf->sungetc();
+                sbuf->sputbackc('.');
+                return true;
+            }
+        }
+        if ((c = sbuf->sbumpc()) == EOF) 
         {
-            
             c=sbuf->sungetc();
-            c=sbuf->sungetc();
-            sbuf->sputbackc(token[tksize-1]);
-            token=token.substr(0,tksize-2);
+            sbuf->sputbackc('.');
+            token=token.substr(0,tksize-1);
             return true;
         }
-        return false;
+        return true;
     }
     else if (is_abrv(token)) 
     {
@@ -280,24 +288,31 @@ bool Tokenizer::dot_proc(string& token, char& c, streambuf* sbuf)
 
 bool Tokenizer::comma_proc (string& token, char& c, streambuf* sbuf) {
     token.push_back(c);
-    
+    int tksize=(int)token.size();
     if (is_nbr(token)) {
         if ((c = sbuf->sbumpc()) != EOF) {
             if (!seps(c)) {
                 token.push_back(c);
                 return false;
             } else {
-                token = token.substr(0,(int)token.size()-1);
+                token = token.substr(0,tksize-1);
                 sbuf->sungetc();
                 sbuf->sputbackc(',');
                 return true;
             }
         }
+        if ((c = sbuf->sbumpc()) == EOF) 
+        {
+            c=sbuf->sungetc();
+            sbuf->sputbackc(',');
+            token=token.substr(0,tksize-1);
+            return true;
+        }
         return true;
 
     } else {
         c = sbuf->sungetc();
-        token = token.substr(0,(int)token.size()-1);
+        token = token.substr(0,tksize-1);
         return true;
     }
 

--- a/src/tokenizer.cc
+++ b/src/tokenizer.cc
@@ -96,6 +96,7 @@ bool Tokenizer::read (string& token, bool newdoc, streambuf* sbuf) {
     char c;
     token.clear();
     newdoc = false;
+    bool do_read = false;
 
     xmlDom dom;
 


### PR DESCRIPTION
We make tokenizing methods thread-safe.
We pass streambuf as an argument to the different tokenizing methods instead of having it as a class attribute. We can then remove the streambuf `sb` attribute from the class.
We remove the istream `in` attribute and the constructor initializing it as well.
For a bit more clarity, we renamed sb to sbuf.
Finally, we change `do_read` to local variable and remove it from class attribute. We itinialized it as false.